### PR TITLE
Changes to avoid compilation errors in Arduino 2.2

### DIFF
--- a/h1_s2_modbus_esp32.ino
+++ b/h1_s2_modbus_esp32.ino
@@ -203,7 +203,7 @@ void WiFiGotIP(WiFiEvent_t event, WiFiEventInfo_t info){
 void WiFiStationDisconnected(WiFiEvent_t event, WiFiEventInfo_t info){
   Serial.println("Disconnected from WiFi access point");
   Serial.print("WiFi lost connection. Reason: ");
-  Serial.println(info.disconnected.reason);
+  Serial.println(info.wifi_sta_disconnected.reason);
   
   Serial.println("Trying to Reconnect");
   WiFi.begin(ssid, password);
@@ -215,9 +215,9 @@ void setup_wifi() {
 
   delay(1000);
 
-  WiFi.onEvent(WiFiStationConnected, SYSTEM_EVENT_STA_CONNECTED);
-  WiFi.onEvent(WiFiGotIP, SYSTEM_EVENT_STA_GOT_IP);
-  WiFi.onEvent(WiFiStationDisconnected, SYSTEM_EVENT_STA_DISCONNECTED);
+  WiFi.onEvent(WiFiStationConnected, ARDUINO_EVENT_WIFI_STA_CONNECTED);
+  WiFi.onEvent(WiFiGotIP, ARDUINO_EVENT_WIFI_STA_GOT_IP);
+  WiFi.onEvent(WiFiStationDisconnected, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
   WiFi.begin(ssid, password);
   WiFi.setAutoReconnect(true);
   WiFi.persistent(true);


### PR DESCRIPTION
avoids WIFI errors in current Arduino version 
e.g.: error: 'union arduino_event_info_t' has no member named 'disconnected'; did you mean 'eth_connected'?
   Serial.println(info.disconnected.reason);

Note:
it is not necessary to add the library "ESP32 BLE for Arduino" BLE library is included in Arduino 2.2