### PR TITLE
Fix setMTU call to BLEDevice instead of BLEClient

### DIFF
--- a/h1_s2_modbus_esp32.ino
+++ b/h1_s2_modbus_esp32.ino
@@ -136,7 +136,7 @@ bool connectToServer_ble() {
     
     previousMillistry = millis();
     pClient->connect(myDevice);  
-    pClient->setMTU(512); ///mtu size equals packet limit-3 250
+    BLEDevice::setMTU(512); ///mtu size equals packet limit-3 250
     Serial.println(" - Connected to server");
     
     previousMillistry = millis();


### PR DESCRIPTION
The compilation under Arduino IDE 1.18 fails because the following error:

`class BLEClient' has no member named 'setMTU'`

The BLEClient class has no setMTU method, it's defined for BLEDevice