### PR TITLE
Fix connection issue with slow network devices

### DIFF
--- a/h1_s2_modbus_esp32.ino
+++ b/h1_s2_modbus_esp32.ino
@@ -218,24 +218,17 @@ void setup_wifi_manager() {
   WiFi.onEvent(WiFiGotIP, ARDUINO_EVENT_WIFI_STA_GOT_IP);
   WiFi.onEvent(WiFiStationDisconnected, ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
 
-  
   WiFiManager wm;
-
-  //reset settings - wipe stored credentials for testing
-  //wm.resetSettings();
+  wm.setConnectTimeout(300);
 
   bool res;
-  // res = wm.autoConnect(); // auto generated AP name from chipid
-  // res = wm.autoConnect("AutoConnectAP"); // anonymous ap
-  res = wm.autoConnect("ESP32_SAJ_MODBUS"); // password protected ap
+  res = wm.autoConnect("ESP32_SAJ_MODBUS");
 
   if(!res) {
-        Serial.println("Failed to connect");
-        // ESP.restart();
+    Serial.println("Failed to connect");
   } 
   else {
-      //if you get here you have connected to the WiFi    
-      Serial.println("connected...yeey :)");
+    Serial.println("connected...yeey :)");
   }
 }
 


### PR DESCRIPTION
When the wireless provider device takes too long to be available, the board enters in the configuration mode, creating an access point.

This change makes wifi manager library to wait up to 300s to connect to the configured wireless network. If there is no network after 300s, then the access point is created.

Of course, if there is no wireless network already configured, it will start the access point mode as soon as it boot up.